### PR TITLE
Update readme syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ class ProductController < ActionController::Base
       #Backend
       uuid = create_product
 
-      redirect_to "/product/compress(uuid)"
+      redirect_to "/product/#{compress(uuid)}"
     end
 
     def index

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ shorten a uuid to a shorter representation and back
 
 I include it in rails controllers to convert uuids to short ones for UI representation and stretch them to standard uuid for use in the backend.
 
-```
+```ruby
 class ProductController < ActionController::Base
     include UuidShortner::GuidDecoder
     include UuidShortner::GuidEncoder


### PR DESCRIPTION
Hi, I added some github flavored code blocks to enable syntax highlighting and thought you might want to merge it.

There also seemed to be a bug with the redirect_to with missing string interpolation separators.